### PR TITLE
Remove c42 tests

### DIFF
--- a/fixtures/cbor/cid.json
+++ b/fixtures/cbor/cid.json
@@ -10,7 +10,7 @@
     "type": "roundtrip",
     "data": "d82a582500015512205891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
     "name": "valid CID with short tag",
-    "tags": ["dag-cbor", "dasl-cid", "c42"],
+    "tags": ["dag-cbor", "dasl-cid"],
     "desc": "a valid CID (raw, SHA-256) using the correct short CBOR representation of the CID tag"
   },
   {

--- a/fixtures/cbor/floats.json
+++ b/fixtures/cbor/floats.json
@@ -10,14 +10,14 @@
     "type": "roundtrip",
     "data": "fb3ff8000000000000",
     "name": "64-bit floats only",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "a 64-bit float, the only valid float representation for dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "f93e00",
     "name": "64-bit floats only",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "a 16-bit float, an invalid input for dag-cbor"
   },
   {
@@ -38,21 +38,21 @@
     "type": "invalid_in",
     "data": "fb7ff8000000000000",
     "name": "long NaN",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an invalid NaN representation, too long (RFC 8949) or because NaNs are invalid (dag-cbor)"
   },
   {
     "type": "roundtrip",
     "data": "fb8000000000000000",
     "name": "negative zero float64",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "testing that negative zero can be roundtripped without becoming positive or an integer"
   },
   {
     "type": "roundtrip",
     "data": "fb0000000000000000",
     "name": "zero float64",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "a standard float like 0.0 shouldn't become an integer"
   },
   {
@@ -73,70 +73,70 @@
     "type": "invalid_in",
     "data": "f97e00",
     "name": "short NaN",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "even short representations of NaN are invalid for dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "f97c00",
     "name": "short Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "fa7f800000",
     "name": "32-bit Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "fb7ff0000000000000",
     "name": "64-bit Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "f9fc00",
     "name": "short -Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "negative infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "faff800000",
     "name": "32-bit -Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "negative infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_in",
     "data": "fbfff0000000000000",
     "name": "64-bit -Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "negative infinity is invalid in dag-cbor"
   },
   {
     "type": "invalid_out",
     "data": "f97e00",
     "name": "NaN",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "NaN should not be encoded for dag-cbor"
   },
   {
     "type": "invalid_out",
     "data": "f97c00",
     "name": "Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "infinity should not be encoded for dag-cbor"
   },
   {
     "type": "invalid_out",
     "data": "f9fc00",
     "name": "-Inf",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "negative infinity should not be encoded for dag-cbor"
   },
   {
@@ -150,7 +150,7 @@
     "type": "invalid_in",
     "data": "f97d00",
     "name": "signaling NaN",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "signaling NaNs are invalid in dag-cbor (like other NaNs)"
   }
 ]

--- a/fixtures/cbor/indefinite.json
+++ b/fixtures/cbor/indefinite.json
@@ -3,28 +3,28 @@
     "type": "invalid_in",
     "data": "bfff",
     "name": "indefinite map",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "maps with undefined length are banned"
   },
   {
     "type": "invalid_in",
     "data": "9fff",
     "name": "indefinite array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "arrays with undefined length are banned"
   },
   {
     "type": "invalid_in",
     "data": "5fff",
     "name": "indefinite byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "byte strings with undefined length are banned"
   },
   {
     "type": "invalid_in",
     "data": "7fff",
     "name": "indefinite string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "strings with undefined length are banned"
   }
 ]

--- a/fixtures/cbor/integer_range.json
+++ b/fixtures/cbor/integer_range.json
@@ -45,14 +45,14 @@
     "type": "roundtrip",
     "data": "c249010000000000000000",
     "name": "smallest unsigned bigint",
-    "tags": ["CBOR-Core", "c42"],
+    "tags": ["CBOR-Core"],
     "desc": "the smallest positive CBOR big integer value, valid in specs that support big integers"
   },
   {
     "type": "roundtrip",
     "data": "c349010000000000000000",
     "name": "highest negative bigint",
-    "tags": ["CBOR-Core", "c42"],
+    "tags": ["CBOR-Core"],
     "desc": "the largest negative CBOR big integer value, valid in specs that support big integers"
   },
   {

--- a/fixtures/cbor/map_keys.json
+++ b/fixtures/cbor/map_keys.json
@@ -10,35 +10,35 @@
     "type": "invalid_in",
     "data": "a10000",
     "name": "map with int key",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "a map with an integer key, invalid to decode dag-cbor"
   },
   {
     "type": "invalid_out",
     "data": "a10000",
     "name": "map with int key",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "a map with an integer key, invalid to encode dag-cbor"
   },
   {
     "type": "roundtrip",
     "data": "a361610161620262616103",
     "name": "map keys in correct order",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with string keys, sorted by their bytes, which also sorts them by length in CBOR"
   },
   {
     "type": "invalid_in",
     "data": "a2616201616100",
     "name": "map keys in incorrect order",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with string keys, not sorted by bytes/length"
   },
   {
     "type": "invalid_in",
     "data": "a2616100616101",
     "name": "duplicate map keys",
-    "tags": ["basic", "dag-cbor", "c42", "dCBOR"],
+    "tags": ["basic", "dag-cbor", "dCBOR"],
     "desc": "a map with duplicate string keys which is invalid by the CBOR spec"
   }
 ]

--- a/fixtures/cbor/short_form.json
+++ b/fixtures/cbor/short_form.json
@@ -3,224 +3,217 @@
     "type": "roundtrip",
     "data": "a1616100",
     "name": "one item map",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded map with one item"
   },
   {
     "type": "invalid_in",
     "data": "b801616100",
     "name": "unnecessary one-byte map definition",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "b90001616100",
     "name": "unnecessary two-byte map definition",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "ba00000001616100",
     "name": "unnecessary four-byte map definition",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "bb0000000000000001616100",
     "name": "unnecessary eight-byte map definition",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a map with a length needlessly encoded as eight bytes"
   },
   {
     "type": "roundtrip",
     "data": "01",
     "name": "small unsigned integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded unsigned integer"
   },
   {
     "type": "invalid_in",
     "data": "1801",
     "name": "unnecessary one-byte unsigned integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an unsigned integer with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "190001",
     "name": "unnecessary two-byte unsigned integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an unsigned integer with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "1a00000001",
     "name": "unnecessary four-byte unsigned integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an unsigned integer with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "1b0000000000000001",
     "name": "unnecessary eight-byte unsigned integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an unsigned integer with a length needlessly encoded as eight bytes"
   },
   {
     "type": "roundtrip",
     "data": "20",
     "name": "small negative integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded negative integer"
   },
   {
     "type": "invalid_in",
     "data": "3800",
     "name": "unnecessary one-byte negative integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a negative integer with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "390000",
     "name": "unnecessary two-byte negative integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a negative integer with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "3a00000000",
     "name": "unnecessary four-byte negative integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a negative integer with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "3b0000000000000000",
     "name": "unnecessary eight-byte negative integer",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a negative integer with a length needlessly encoded as eight bytes"
   },
   {
     "type": "roundtrip",
     "data": "40",
     "name": "empty byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded empty byte string"
   },
   {
     "type": "invalid_in",
     "data": "5800",
     "name": "unnecessary one-byte byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a byte string with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "590000",
     "name": "unnecessary two-byte byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a byte string with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "5a00000000",
     "name": "unnecessary four-byte byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a byte string with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "5b0000000000000000",
     "name": "unnecessary eight-byte byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a byte string with a length needlessly encoded as eight bytes"
   },
   {
     "type": "roundtrip",
     "data": "60",
     "name": "empty string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded empty string"
   },
   {
     "type": "invalid_in",
     "data": "7800",
     "name": "unnecessary one-byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a string with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "790000",
     "name": "unnecessary two-byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a string with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "7a00000000",
     "name": "unnecessary four-byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a string with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "7b0000000000000000",
     "name": "unnecessary eight-byte string",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a string with a length needlessly encoded as eight bytes"
   },
   {
     "type": "roundtrip",
     "data": "80",
     "name": "empty array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "a valid, minimally encoded empty map"
   },
   {
     "type": "invalid_in",
     "data": "9800",
     "name": "unnecessary one-byte array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an array with a length needlessly encoded as separate byte"
   },
   {
     "type": "invalid_in",
     "data": "990000",
     "name": "unnecessary two-byte array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an array with a length needlessly encoded as two bytes"
   },
   {
     "type": "invalid_in",
     "data": "9a00000000",
     "name": "unnecessary four-byte array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an array with a length needlessly encoded as four bytes"
   },
   {
     "type": "invalid_in",
     "data": "9b0000000000000000",
     "name": "unnecessary eight-byte array",
-    "tags": ["rfc8949", "dag-cbor", "c42"],
+    "tags": ["rfc8949", "dag-cbor"],
     "desc": "an array with a length needlessly encoded as eight bytes"
   },
   {
     "type": "invalid_in",
     "data": "c34a00010000000000000000",
     "name": "bigint with leading zero bytes",
-    "tags": ["rfc8949", "c42"],
+    "tags": ["rfc8949"],
     "desc": "a big integer encoded with unnecessary leading zeros"
-  },
-  {
-    "type": "invalid_in",
-    "data": "c243010000",
-    "name": "value too small for bigint",
-    "tags": ["c42"],
-    "desc": "a big integer encoded with a value that could be a regular integer instead"
   }
 ]

--- a/fixtures/cbor/simple.json
+++ b/fixtures/cbor/simple.json
@@ -3,14 +3,14 @@
     "type": "invalid_in",
     "data": "f7",
     "name": "simple value 'undefined'",
-    "tags": ["dag-cbor", "c42", "dCBOR"],
+    "tags": ["dag-cbor", "dCBOR"],
     "desc": "the CBOR value undefined is banned for decoding by some specs"
   },
   {
     "type": "invalid_out",
     "data": "f7",
     "name": "simple value 'undefined'",
-    "tags": ["dag-cbor", "c42", "dCBOR"],
+    "tags": ["dag-cbor", "dCBOR"],
     "desc": "the CBOR value undefined is banned for encoding by some specs",
     "id": "undefined_invalid_out"
   },

--- a/fixtures/cbor/tags.json
+++ b/fixtures/cbor/tags.json
@@ -3,14 +3,14 @@
     "type": "invalid_in",
     "data": "d8207368747470733a2f2f6578616d706c652e636f6d",
     "name": "tag that isn't 42",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "all tags other than 42 (CID) are banned by dag-cbor"
   },
   {
     "type": "invalid_out",
     "data": "c07819323032352d30352d32365431363a31383a31372d30343a3030",
     "name": "tagged object (datetime)",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "an object that would be encoded as a CBOR tag (a datetime in this case) should be rejected by dag-cbor encoders",
     "id": "datetime_invalid_out"
   },
@@ -18,7 +18,7 @@
     "type": "invalid_in",
     "data": "d9d9f700",
     "name": "self-describing CBOR",
-    "tags": ["dag-cbor", "c42"],
+    "tags": ["dag-cbor"],
     "desc": "the self-describing CBOR tag, 55799, should also be forbidden"
   }
 ]

--- a/fixtures/cbor/utf8.json
+++ b/fixtures/cbor/utf8.json
@@ -31,7 +31,7 @@
     "type": "roundtrip",
     "data": "6365cc81",
     "name": "text not in Unicode Normalization Form C",
-    "tags": ["dag-cbor", "CDE", "CBOR-Core", "c42"],
+    "tags": ["dag-cbor", "CDE", "CBOR-Core"],
     "desc": "all specs except dCBOR don't mention Unicode normalization, so this test ensures that libraries don't alter strings for the purpose of normalization"
   }
 ]

--- a/report/template.html
+++ b/report/template.html
@@ -79,7 +79,7 @@
           ></div>
           {% endfor %}
         </div>
-        <h3>dag-cbor</h3>
+        <h3>dag-cbor/drisl/c42</h3>
         <div class="chart-group">
           {% for lib, passfail in summary["dag-cbor"].items() %}
           <div
@@ -116,12 +116,11 @@
               <option value="all">All tags</option>
               <option value="basic">Basic functionality</option>
               <option value="rfc8949">RFC 8949 §4.2</option>
-              <option value="dag-cbor">dag-cbor</option>
+              <option value="dag-cbor/drisl/c42">dag-cbor/drisl/c42</option>
               <option value="dasl-cid">DASL CID spec</option>
               <option value="CBOR-Core">CBOR::Core</option>
               <option value="dCBOR">dCBOR</option>
               <option value="CDE">CDE</option>
-              <option value="c42">CBOR/c-42</option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
c42 is now equal to DAG-CBOR, no BigNums are supported anymore. Hence remove that tag completely.