### PR TITLE
Disallow negative zero

### DIFF
--- a/fixtures/cbor/floats.json
+++ b/fixtures/cbor/floats.json
@@ -42,11 +42,12 @@
     "desc": "an invalid NaN representation, too long (RFC 8949) or because NaNs are invalid (dag-cbor)"
   },
   {
-    "type": "roundtrip",
+    "type": "invalid_in",
     "data": "fb8000000000000000",
     "name": "negative zero float64",
     "tags": ["dag-cbor"],
-    "desc": "testing that negative zero can be roundtripped without becoming positive or an integer"
+    "desc": "negative zero is invalid in dag-cbor",
+    "id": "negative_zero_invalid_in"
   },
   {
     "type": "roundtrip",
@@ -138,6 +139,14 @@
     "name": "-Inf",
     "tags": ["dag-cbor"],
     "desc": "negative infinity should not be encoded for dag-cbor"
+  },
+  {
+    "type": "invalid_out",
+    "data": "fb8000000000000000",
+    "name": "negative zero",
+    "tags": ["dag-cbor"],
+    "desc": "negative zero should not be encoded for dag-cbor",
+    "id": "negative_zero_invalid_out"
   },
   {
     "type": "invalid_in",

--- a/harnesses/js/main.js
+++ b/harnesses/js/main.js
@@ -7,7 +7,9 @@ import atcutePkg from "./node_modules/@atcute/cbor/package.json" with { type: "j
 
 // Test IDs to skip
 const skippedTestIDs = [
-  // Add test IDs here to skip them
+  // Both @ipld/dag-cbor and @atcute/cbor don't error, but encode -0.0 as the
+  // equal integer 0 instead, so there are no forbidden bytes to reject.
+  "negative_zero_invalid_out",
 ];
 
 let roundtrip, invalidEncode, invalidDecode, link, version;

--- a/harnesses/serde_ipld_dagcbor/src/main.rs
+++ b/harnesses/serde_ipld_dagcbor/src/main.rs
@@ -8,10 +8,16 @@ use std::io::Cursor;
 include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
 const SKIPPED_TEST_IDS: &[&str] = &[
+    // ciborium decodes into a custom map, hence it can be encoded by serde_ipld_dagcbor.
     "datetime_invalid_out",
+    // ciborium decodes into a custom map, hence it can be encoded by serde_ipld_dagcbor.
     "bignum_invalid_out",
+    // ciborium converts it into a `null`, hence serder_ipld_dagcbor can encode it.
     "undefined_invalid_out",
+    // ciborium cannot decode this value, hence the test would fail early.
     "unassigned_invalid_out",
+    // serde_ipld_dagcbor does not error, but encodes as the equal `0.0` instead.
+    "negative_zero_invalid_out",
 ];
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
The DAG-CBOR/cbor42/DRISL specs were update to explicitly disallow negative zero (`-0.0`). Implementation might encode such a value as a positive zero (`0.0`) which is equal according to the IEEE 754 specificaiton.